### PR TITLE
added leihlah and deleila

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Infos zu bestehenden Leihläden, Konzepten und Software.
 
 ### Deutschland
 
-#### Teilbar Stuttgard
+#### Teilbar Stuttgart
   
 * Homepage: https://teilbar.eu/
-* Buchungs-System: https://teilbar.eu/teilraum/was-wir-teilen/
+* [Buchungs-System (WP & CommonsBooking)](https://teilbar.eu/teilraum/was-wir-teilen/)
 
 #### Leihladen Kiel
 
@@ -77,6 +77,16 @@ Infos zu bestehenden Leihläden, Konzepten und Software.
 
 * https://westhausener-geraetering-weshare.de/
 * [Buchungs-System (WP & CommonsBooking)](https://westhausener-geraetering-weshare.de/geraeteliste)
+
+#### Deleila (Lippe im Wandel)
+
+* https://lippeimwandel.de/leihkatalog/
+* [Buchungs-System (WP & CommonsBooking)](https://lippeimwandel.de/leihkatalog/)
+
+#### Leihla Fürth
+
+* https://leihla.bluepingu.de/
+* [Buchungs-System (WP & CommonsBooking)](https://leihla.bluepingu.de/)
 
 ### Österreich
 


### PR DESCRIPTION
Hier noch ein paar Leihläden die wir durch CommonsBooking kennen. Auch wenn es nicht so aussieht, teilbar.eu nutzt CommonsBooking, wenn auch mit eigenen Templates für die Artikelanzeige.
